### PR TITLE
Setting default no of threads as 1

### DIFF
--- a/src/inference.py
+++ b/src/inference.py
@@ -62,7 +62,7 @@ class ThreadedModelRequest:
 
     """
 
-    def __init__(self, deployment_details, n_threads=2):
+    def __init__(self, deployment_details, n_threads=1):
         self.n_threads = n_threads
         self.deployment_details = deployment_details
         self.model_service_url = self.get_model_call_endpoint()


### PR DESCRIPTION
## Problem
AMP's below step is failing intermittently
```yaml
type: run_session
name: Run Simulation
script: scripts/simulate.py
memory: 4
cpu: 2
```
<img width="802" alt="Screenshot 2024-02-22 at 1 43 57 PM" src="https://github.com/cloudera/CML_AMP_Continuous_Model_Monitoring/assets/19422305/a0245e26-0f31-4c8a-9be8-fd73cdd630dc">

The failures are due to the current model serving setup, where one replica can handle only one request at a time. Consequently, model requests initiated from the session are not succeeding.

![Screenshot 2024-02-15 at 7 43 05 PM](https://github.com/cloudera/CML_AMP_Continuous_Model_Monitoring/assets/19422305/8a9eef24-af14-4cd5-aa81-aa43cb3b50e3)

## Changes Made
- updated default no of threads as 1

## Testing
<img width="837" alt="Screenshot 2024-02-22 at 1 16 14 PM" src="https://github.com/cloudera/CML_AMP_Continuous_Model_Monitoring/assets/19422305/8b6c3259-bfb2-466f-8c70-02c628177d33">



