### PR TITLE
 Retrieve the model info using the prefix name instead of the full name.

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -86,14 +86,15 @@ class ApiUtility:
 
         # gather model details
         models = (
-            self.client.list_models(project_id=project_id, async_req=True)
+            # fetch models for the project, sorting them in descending order by model name.
+            self.client.list_models(project_id=project_id, sort="-name" ,async_req=True)
             .get()
             .to_dict()
         )
         model_info = [
-            model for model in models["models"] if model["name"] == model_name
+            model for model in models["models"] if model["name"].startswith(model_name)
         ][0]
-
+        model_name = model_info["name"]
         model_id = model_info["id"]
         model_crn = model_info["crn"]
         model_access_key = model_info["access_key"]


### PR DESCRIPTION
## Problem
We recently introduced workload versioning as a component of the AMP restart feature. For example, a model might be named **Price Regressor v1.2**. However, our current implementation in AMP fetches model information using the exact name, such as **Price Regressor**. To address this, have updated the AMP to retrieve the model information using the prefix name instead of the full name.

## Testing
PRE:

<img width="750" alt="Screenshot 2024-03-26 at 8 05 52 PM" src="https://github.com/cloudera/CML_AMP_Continuous_Model_Monitoring/assets/19422305/c619e7d9-0932-45d6-8bb5-a6367a6395c1">

POST:

<img width="854" alt="Screenshot 2024-03-26 at 8 03 32 PM" src="https://github.com/cloudera/CML_AMP_Continuous_Model_Monitoring/assets/19422305/f25df3d8-88fa-4871-ad30-c31d1b10783e">



